### PR TITLE
Clarify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ The Go implementation of the Dispatch protocol
 
 ## To install
 
-1. install go
-2. navigate to your $GOPATH/src folder
-3. git clone this project
-4. ```cd disgo```
-5. ```go get``` (kinda like npm install)
+1. Install [Go](https://golang.org/)
+2. `go get github.com/DispatchLabs/disgo`
+3. `cd $GOPATH/src/github.com/DispatchLabs/disgo`
+4. `go get`
 
 ## To run
 


### PR DESCRIPTION
Before: instructions had you navigate to the wrong folders to run `git clone`. Now: `go get` clones the project into the proper folders without any navigation needed.