### PR TITLE
fixed problem with scoped variable

### DIFF
--- a/dapos/dapos_handshake.go
+++ b/dapos/dapos_handshake.go
@@ -140,7 +140,7 @@ func (this *DAPoSService) gossipWorker() {
 		select {
 		case gossip = <-this.gossipChan:
 
-			go func(theGossip *types.Gossip) {
+			go func(gossip *types.Gossip) {
 
 				// Gossip timeout?
 				elapsedMilliSeconds := utils.ToMilliSeconds(time.Now()) - gossip.Rumors[0].Time


### PR DESCRIPTION
This was causing very strange behavior with gossip randomly just not being processed anymore.  Scoped variable was outside a threaded go function which cause really random behavior under load