### PR TITLE
fix DG-763 for 2.1.1 patch

### DIFF
--- a/commons/types/node.go
+++ b/commons/types/node.go
@@ -22,8 +22,6 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/dispatchlabs/disgo/commons/utils"
 	"github.com/patrickmn/go-cache"
-	"time"
-	//"reflect"
 	"strings"
 )
 
@@ -54,14 +52,9 @@ func (this Node) TypeKey() string {
 }
 
 //Cache
-func (this *Node) Cache(cache *cache.Cache, time_optional ...time.Duration) {
-	TTL := NodeTTL
-	if len(time_optional) > 0 {
-		TTL = time_optional[0]
-	}
-
-	cache.Set(this.Key(), this, TTL)
-	cache.Set(this.TypeKey(), this.Key(), TTL)
+func (this *Node) Cache(c *cache.Cache) {
+	c.Set(this.Key(), this, cache.NoExpiration)
+	c.Set(this.TypeKey(), this.Key(), cache.NoExpiration)
 }
 
 //Persist

--- a/disgover/disgover_service.go
+++ b/disgover/disgover_service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/libp2p/go-libp2p-kbucket"
 	"github.com/libp2p/go-libp2p-peer"
 	"github.com/libp2p/go-libp2p-peerstore"
-	"github.com/patrickmn/go-cache"
 )
 
 var disGoverServiceInstance *DisGoverService
@@ -102,7 +101,7 @@ func (this *DisGoverService) Go() {
 		}
 
 		for _, delegate := range delegates {
-			delegate.Cache(services.GetCache(), cache.NoExpiration)
+			delegate.Cache(services.GetCache())
 		}
 	}
 

--- a/disgover/disgover_transport_grpc.go
+++ b/disgover/disgover_transport_grpc.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"github.com/patrickmn/go-cache"
 )
 
 // WithGrpc - Runs the DisGover service with GRPC transport
@@ -114,7 +113,7 @@ func (this *DisGoverService) UpdateGrpc(ctx context.Context, nodeList *proto.Nod
 
 	// Cache delegates.
 	for _, delegate := range nodeList.Delegates {
-		convertToDomain(delegate).Cache(services.GetCache(), cache.NoExpiration)
+		convertToDomain(delegate).Cache(services.GetCache())
 	}
 
 	utils.Info(fmt.Sprintf("delegates updated [count=%d]", len(nodeList.Delegates)))


### PR DESCRIPTION
TTL was always being set to 24 hours. Because the no expiration constant has a value of -1 the check for the optional parameter always failed and the cache time to live is ALWAYS set to 24 hours.