### PR TITLE
Dg 833 DG-834 DG-838

### DIFF
--- a/commons/types/constants.go
+++ b/commons/types/constants.go
@@ -28,6 +28,7 @@ const (
 	TxReceiveWiggle    = 100 // 100ms
 	GossipQueueTimeout = time.Second * 5
 	GossipTimeout      = 1000 //1 second  //will continue to decrease until we find best value
+	TxFutureLimit	   = time.Minute * 3
 )
 
 // Requests

--- a/commons/types/constants.go
+++ b/commons/types/constants.go
@@ -25,8 +25,8 @@ import (
 // Timouts -- currently calculated in milliseconds.
 const (
 	TxReceiveTimeout   = 3000 //1 second
-	TxReceiveWiggle    = 100 // 100ms
-	GossipQueueTimeout = time.Second * 5
+	//TxReceiveWiggle    = 100 // 100ms
+	//GossipQueueTimeout = time.Second * 5
 	GossipTimeout      = 1000 //1 second  //will continue to decrease until we find best value
 	TxFutureLimit	   = time.Minute * 3
 )

--- a/commons/types/transaction.go
+++ b/commons/types/transaction.go
@@ -780,9 +780,14 @@ func (this Transaction) Equals(other string) bool {
 }
 
 func checkTime(txTime int64) (int64, error) {
-	now := utils.ToMilliSeconds(time.Now())
-	if now + TxReceiveWiggle < txTime { // Adding "wiggle room" to allow for clock variances
-		return txTime, errors.Errorf(fmt.Sprintf("transaction time cannot be in the future (delegate time: %v tx.time: %v)", now, txTime))
+	// Adding "future times managed by the constant"
+	now := time.Now()
+	futureTime := now.Add(TxFutureLimit)
+	nowWithFutureLimit := utils.ToMilliSeconds(futureTime)
+
+	if nowWithFutureLimit < txTime {
+		delta := time.Millisecond * time.Duration(txTime - utils.ToMilliSeconds(now))
+		return txTime, errors.Errorf(fmt.Sprintf("transaction time cannot be this far in the future (Ahead by: %v )", delta))
 	} else if txTime < 0 {
 		return txTime, errors.Errorf("transaction time cannot be negative")
 	}

--- a/dapos/dapos_handshake.go
+++ b/dapos/dapos_handshake.go
@@ -185,7 +185,13 @@ func (this *DAPoSService) gossipWorker() {
 						this.gossipQueue.Push(gossip)
 
 						go func() {
-							time.Sleep(types.GossipQueueTimeout)
+							//adding timeout as a function of tx time.  If tx is in the future, add future delta to the default timeout
+							delta := gossip.Transaction.Time - utils.ToMilliSeconds(time.Now())
+							timeout := types.GossipQueueTimeout
+							if delta > 0 {
+								timeout = time.Millisecond * time.Duration(delta) + timeout
+							}
+							time.Sleep(timeout)
 							this.timoutChan <- true
 						}()
 					}

--- a/dapos/dapos_handshake.go
+++ b/dapos/dapos_handshake.go
@@ -187,7 +187,8 @@ func (this *DAPoSService) gossipWorker() {
 						go func() {
 							//adding timeout as a function of tx time.  If tx is in the future, add future delta to the default timeout
 							delta := gossip.Transaction.Time - utils.ToMilliSeconds(time.Now())
-							timeout := types.GossipQueueTimeout
+							totalMilliseconds := ( types.GossipTimeout * len(delegateNodes) ) + types.TxReceiveTimeout
+							timeout := time.Duration(totalMilliseconds)
 							if delta > 0 {
 								timeout = time.Millisecond * time.Duration(delta) + timeout
 							}


### PR DESCRIPTION
Submission of transactions can now be up to some delta in time in the future.  A constant is used to manage the delta value.  In addition, the Gossip queue timeout for future transactions is now a function of time (stays in the queue for default gossip timeout + amount of time in the future (from the transaction timestamp))
All transactions that are not in the future still use the default gossip queue timeout.  If we want to also make this a function of time, it is a simple change, but I think that there are a number of considerations to account for there that I'm currently don't think we should do.  I think the minimum should be the dictated gossip queue timeout.