### PR TITLE
removed dropping non-responsive delegates

### DIFF
--- a/dapos/dapos_handshake.go
+++ b/dapos/dapos_handshake.go
@@ -216,7 +216,6 @@ func (this *DAPoSService) gossipWorker() {
 				peerGossip, err := this.peerGossipGrpc(*node, gossip)
 				if err != nil {
 					utils.Warn(err)
-					time.Sleep(time.Second *2)
 					this.gossipChan <- gossip
 					return
 				}

--- a/dapos/dapos_transport_grpc.go
+++ b/dapos/dapos_transport_grpc.go
@@ -185,13 +185,13 @@ func (this *DAPoSService) peerGossipGrpc(node types.Node, gossip *types.Gossip) 
 	response, err := client.GossipGrpc(contextWithTimeout, &proto.Request{Payload: gossip.String()})
 	if err != nil {
 		utils.Error(fmt.Sprintf("cannot connect to node [host=%s, port=%d]", node.GrpcEndpoint.Host, node.GrpcEndpoint.Port), err)
-		txn := services.NewTxn(true)
-		defer txn.Discard()
-
-		unsetErr := node.Unset(txn, services.GetCache())
-		if unsetErr != nil {
-			utils.Error(unsetErr)
-		}
+		//txn := services.NewTxn(true)
+		//defer txn.Discard()
+		//
+		//unsetErr := node.Unset(txn, services.GetCache())
+		//if unsetErr != nil {
+		//	utils.Error(unsetErr)
+		//}
 		return nil, err
 	}
 	remoteGossip, err := types.ToGossipFromJson([]byte(response.Payload))


### PR DESCRIPTION
List size always remains the same. If a delegate drops, it will continue to try to communicate with them.