### PR TITLE
Fix to get reciipt from cache when getting transaction from cache

### DIFF
--- a/commons/types/transaction.go
+++ b/commons/types/transaction.go
@@ -182,6 +182,12 @@ func ToTransactionFromCache(cache *cache.Cache, hash string) (*Transaction, erro
 		return nil, ErrNotFound
 	}
 	transaction := value.(*Transaction)
+	receipt, err :=  ToReceiptFromCache(cache, transaction.Hash)
+	if err != nil {
+		utils.Error(err)
+	} else {
+		transaction.Receipt = *receipt
+	}
 	return transaction, nil
 }
 


### PR DESCRIPTION
This should solve a number of issues where there is a failure on the transaction and there was not receipt to get status for it.