### PR TITLE
DG-935 modified Gossip to not gossip so poorly

### DIFF
--- a/commons/helper/abi_helper.go
+++ b/commons/helper/abi_helper.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/dispatchlabs/disgo/commons/crypto"
 	"github.com/dispatchlabs/disgo/commons/types"
+	"github.com/dispatchlabs/disgo/commons/utils"
 	"github.com/dispatchlabs/disgo/dvm/ethereum/abi"
 	"github.com/pkg/errors"
 )
 
 func GetConvertedParams(tx *types.Transaction) ([]interface{}, error) {
-
+	utils.Info("GetConvertedParams --> ", tx.Params)
 	theABI, err := GetABI(tx.Abi)
 	if err != nil {
 		return nil, err
@@ -28,7 +29,7 @@ func GetConvertedParams(tx *types.Transaction) ([]interface{}, error) {
 				return tx.Params, nil
 			}
 			if len(v.Inputs) != len(tx.Params) {
-				return nil, errors.New(fmt.Sprintf("This method %s, requires %d parameters and %d are provided", tx.Method, len(v.Inputs), len(tx.Params)))
+				return nil, errors.New(fmt.Sprintf("The method %s, requires %d parameters and %d are provided", tx.Method, len(v.Inputs), len(tx.Params)))
 			}
 			for i := 0; i < len(v.Inputs); i++ {
 				arg := v.Inputs[i]
@@ -59,7 +60,7 @@ func GetConvertedParams(tx *types.Transaction) ([]interface{}, error) {
 		}
 	}
 	if !found {
-		return nil, errors.New(fmt.Sprintf("This method %s is not valid for this contract", tx.Method))
+		return nil, errors.New(fmt.Sprintf("This method '%s' is not valid for this contract", tx.Method))
 	}
 	return result, nil
 }
@@ -224,11 +225,15 @@ func getValue(arg abi.Argument, value interface{}) (interface{}, error) {
 }
 
 func GetABI(data string) (*abi.ABI, error) {
+	runes := []rune(data)
+	// ... Convert back into a string from rune slice.
+	safeSubstring := string(runes[0:10])
+	utils.Info("GetAbi %s\n%s\n", safeSubstring, utils.GetCallStackWithFileAndLineNumber())
 	bytes, err := hex.DecodeString(data)
-	//print("ABI: %v\n", string(bytes) )
 	var abi abi.ABI
 	err = abi.UnmarshalJSON(bytes)
 	if err != nil {
+		utils.Error(err, utils.GetCallStackWithFileAndLineNumber())
 		return nil, errors.New(fmt.Sprintf("The ABI provided is not a valid ABI structure: %s", string(bytes)))
 	}
 	return &abi, nil

--- a/commons/queue/gossip_queue.go
+++ b/commons/queue/gossip_queue.go
@@ -29,19 +29,17 @@ func NewGossipQueue() *GossipQueue {
 
 // - Push onto the queue and then resort (latest to earliest) also add to fast Exists map for quick checks
 func (gq *GossipQueue) Push(gossip *types.Gossip) {
-	utils.Debug("GossipQueue --> Push")
+	utils.Debug("GossipQueue.Push --> ", gossip.Transaction.Hash)
 	itm := Item{gossip, gossip.Transaction.Time, gq.Queue.Len() + 1}
-	HeapPush(gq.Queue, &itm)
 	gq.ExistsMap.Put(gossip.Transaction.Hash)
+	HeapPush(gq.Queue, &itm)
 }
 
 // - Push onto the queue and then resort (latest to earliest) also add to fast Exists map for quick checks
 func (gq *GossipQueue) Pop() *types.Gossip {
-	utils.Debug("GossipQueue --> Pop: ")
-
 	itm := HeapPop(gq.Queue).(*Item)
 	gossip := itm.Data.(*types.Gossip)
-	utils.Debug("GossipQueue --> Pop: ", gossip.Transaction.ToTime())
+	utils.Debug("GossipQueue.Pop --> ", gossip.Transaction.Hash)
 	gq.ExistsMap.Delete(gossip.Transaction.Hash)
 	return gossip
 }

--- a/commons/services/grpc_service.go
+++ b/commons/services/grpc_service.go
@@ -96,6 +96,7 @@ func GetGrpcConnection(address string, host string, port int64) (*grpc.ClientCon
 	clientConn, err := pool.Get(context.Background())
 	if err != nil {
 		utils.Error("Client connection error ", err)
+		return nil, err
 	}
 	defer clientConn.Close()
 	return clientConn.ClientConn, nil
@@ -109,7 +110,7 @@ func setupConnectionPoolForPeer(address string, host string, port int64) {
 		if err != nil {
 			utils.Error("Failed to start gRPC connection: %v", err)
 		}
-		utils.Info("Connected to node at", host, port)
+		utils.Debug("Connected to node at", host, port)
 		return conn, err
 	}
 	pool, err := grpcpool.New(factory, 5, 5, time.Second* 5)

--- a/commons/types/gossip.go
+++ b/commons/types/gossip.go
@@ -35,8 +35,39 @@ func (this Gossip) Key() string {
 	return fmt.Sprintf("table-gossip-%s", this.Transaction.Hash)
 }
 
+func (this Gossip) RumorKey(txHash string) string {
+	return fmt.Sprintf("cache-rumor-%s", txHash)
+}
+
+func (this *Gossip) HaveSent(cache *cache.Cache, txHash, delegateAddress string) bool {
+	value, ok := cache.Get(this.RumorKey(txHash))
+	if !ok{
+		return false
+	}
+	addresses := value.([]string)
+	for _, address := range addresses {
+		if address == delegateAddress {
+			return true
+		}
+	}
+	return false
+}
+
+func (this *Gossip) CacheSentDelegate(cache *cache.Cache, txHash, nodeAddress string) {
+	value, ok := cache.Get(this.RumorKey(txHash))
+	array := make([]string, 0)
+	if !ok {
+		array = append(array, nodeAddress)
+		cache.Set(this.RumorKey(txHash), array, GossipCacheTTL)
+	} else {
+		addresses := value.([]string)
+		array = append(addresses, nodeAddress)
+	}
+	cache.Set(this.RumorKey(txHash), array, GossipCacheTTL)
+}
+
 // Cache
-func (this *Gossip) Cache(cache *cache.Cache){
+func (this *Gossip) Cache(cache *cache.Cache) {
 	cache.Set(this.Key(), this, GossipCacheTTL)
 }
 

--- a/commons/types/rumor.go
+++ b/commons/types/rumor.go
@@ -248,7 +248,7 @@ func ValidateTimeDelta(rumors []Rumor) bool {
 	timing = append(timing, initialTime)
 
 	if  now - rumorSorter.Rumors[len-1].Time > GossipTimeout {
-		msg := fmt.Sprintf("gossip to local delegate %s took %v", rumorSorter.Rumors[len-1].Address, initialTime)
+		msg := fmt.Sprintf("gossip for [hash=%s] to local delegate [adresss=%s] took [time=%v]", rumorSorter.Rumors[len-1].TransactionHash, rumorSorter.Rumors[len-1].Address, initialTime)
 		utils.Info(msg)
 		result = false
 	}
@@ -257,8 +257,8 @@ func ValidateTimeDelta(rumors []Rumor) bool {
 			gossipTime := rumorSorter.Rumors[i].Time - rumorSorter.Rumors[i-1].Time
 			timing = append(timing, gossipTime)
 			if gossipTime > GossipTimeout {
-				msg := fmt.Sprintf("gossip between delegate %s and delegage %s took %v", rumorSorter.Rumors[i].Address, rumorSorter.Rumors[i-1].Address, gossipTime)
-				utils.Info(msg)
+				msg := fmt.Sprintf("gossip for [hash=%s] between delegate [adresss=%s] and delegage [adresss=%s] took [time=%v]", rumorSorter.Rumors[i].TransactionHash, rumorSorter.Rumors[i].Address, rumorSorter.Rumors[i-1].Address, gossipTime)
+				utils.Warn(msg)
 				result = false
 			}
 		}

--- a/dapos/dapos_api.go
+++ b/dapos/dapos_api.go
@@ -119,7 +119,7 @@ func (this *DAPoSService) NewTransaction(transaction *types.Transaction) *types.
 		response.HumanReadableStatus = types.StatusNotDelegateAsHumanReadable
 	}
 
-	utils.Info(fmt.Sprintf("new transaction [hash=%s, status=%s]", transaction.Hash, response.Status))
+	utils.Debug(fmt.Sprintf("new transaction [hash=%s, status=%s]", transaction.Hash, response.Status))
 	return response
 }
 
@@ -152,7 +152,7 @@ func (this *DAPoSService) GetTransaction(hash string) *types.Response {
 		response.Status = types.StatusNotDelegate
 		response.HumanReadableStatus = types.StatusNotDelegateAsHumanReadable
 	}
-	utils.Info(fmt.Sprintf("retrieved transaction [hash=%s, status=%s]", hash, response.Status))
+	utils.Debug(fmt.Sprintf("retrieved transaction [hash=%s, status=%s]", hash, response.Status))
 
 	return response
 }

--- a/dapos/dapos_handshake.go
+++ b/dapos/dapos_handshake.go
@@ -19,24 +19,26 @@ package dapos
 import (
 	"fmt"
 	"math/rand"
+	"math/big"
+	"strings"
+	"time"
+	"encoding/hex"
 
 	"github.com/dgraph-io/badger"
+	"github.com/dispatchlabs/disgo/commons/helper"
 	"github.com/dispatchlabs/disgo/commons/services"
 	"github.com/dispatchlabs/disgo/commons/types"
 	"github.com/dispatchlabs/disgo/commons/utils"
 	"github.com/dispatchlabs/disgo/disgover"
-
-	"encoding/hex"
-	"math/big"
-	"strings"
-	"time"
-
 	"github.com/dispatchlabs/disgo/dvm"
 	"github.com/dispatchlabs/disgo/dvm/ethereum/abi"
 )
 
+var delegateMap = map[string]*types.Node{}
+
 // startGossiping
 func (this *DAPoSService) startGossiping(transaction *types.Transaction) *types.Response {
+	utils.Debug("startGossiping")
 	txn := services.NewTxn(false)
 	defer txn.Discard()
 
@@ -71,21 +73,20 @@ func (this *DAPoSService) startGossiping(transaction *types.Transaction) *types.
 		utils.Info(fmt.Sprintf("already processing this transaction [hash=%s]", transaction.Hash))
 		return types.NewResponseWithStatus(types.StatusAlreadyProcessingTransaction, "Transaction is already being processed")
 	}
-
 	// Cache gossip with my rumor.
 	gossip := types.NewGossip(*transaction)
 	rumor := types.NewRumor(types.GetAccount().PrivateKey, types.GetAccount().Address, transaction.Hash)
 	gossip.Rumors = append(gossip.Rumors, *rumor)
 
-	cacheOnFirstReceive(gossip)
+	this.cacheOnFirstReceive(gossip)
 	this.gossipChan <- gossip
 
 	return types.NewResponseWithStatus(types.StatusPending, "Pending")
 }
 
-func cacheOnFirstReceive(gossip *types.Gossip) {
+func (this *DAPoSService) cacheOnFirstReceive(gossip *types.Gossip) {
 	// Cache receipt.
-	utils.Info("Cache receipt")
+	utils.Debug(fmt.Sprintf("First receipt of transaction [hash=%s] [Rumors=%d]", gossip.Transaction.Hash, len(gossip.Rumors)))
 	receipt := types.NewReceipt(gossip.Transaction.Hash)
 	receipt.Cache(services.GetCache())
 
@@ -94,6 +95,21 @@ func cacheOnFirstReceive(gossip *types.Gossip) {
 
 	// transaction.Receipt.Status = types.StatusReceived
 	gossip.Transaction.Cache(services.GetCache())
+
+	delegateNodes, err := types.ToNodesByTypeFromCache(services.GetCache(), types.TypeDelegate)
+	if err != nil {
+		utils.Error(err)
+		return
+	}
+	for _, node := range delegateNodes {
+		haveSent := gossip.HaveSent(services.GetCache(), gossip.Transaction.Hash, node.Address)
+		isThisAddress := node.Address == disgover.GetDisGoverService().ThisNode.Address
+
+		if !haveSent && !isThisAddress {
+			this.peerGossipGrpc(*node, gossip)
+		}
+	}
+
 }
 
 // Temp_ProcessTransaction -
@@ -117,22 +133,26 @@ func (this *DAPoSService) Temp_ProcessTransaction(transaction *types.Transaction
 }
 
 // synchronizeGossip
-func (this *DAPoSService) synchronizeGossip(gossip *types.Gossip) (*types.Gossip, error) {
+func (this *DAPoSService) synchronizeGossip(gossip *types.Gossip) (*types.Gossip, error, bool) {
 
 	// PersistAndCache synchronizedGossip.
 	var synchronizedGossip *types.Gossip
+	hasAll := false
 	ourGossip, err := types.ToGossipFromCache(services.GetCache(), gossip.Transaction.Hash)
 	if err != nil {
-		//This is the first time receiving this gossip
-		cacheOnFirstReceive(gossip)
 		synchronizedGossip = gossip
 	} else {
 		synchronizedGossip = ourGossip
 		for _, rumor := range gossip.Rumors {
+			hasAll = true
+			if !ourGossip.ContainsRumor(rumor.Address) {
+				hasAll = false
+			}
 			if !synchronizedGossip.ContainsRumor(rumor.Address) && rumor.Verify() { // We don't want to propagate cryptographic lies.
 				synchronizedGossip.Rumors = append(synchronizedGossip.Rumors, rumor)
 			}
 		}
+		//we have already seen all of these rumors, so we don't want to put them back into our Gossip worker
 	}
 
 	// Did rumor?
@@ -147,13 +167,15 @@ func (this *DAPoSService) synchronizeGossip(gossip *types.Gossip) (*types.Gossip
 		// We don't want to propagate cryptographic lies.
 		err = gossip.Transaction.Verify()
 		if err == nil {
-			synchronizedGossip.Rumors = append(gossip.Rumors, *types.NewRumor(types.GetAccount().PrivateKey, types.GetAccount().Address, gossip.Transaction.Hash))
+			synchronizedGossip.Rumors = append(synchronizedGossip.Rumors, *types.NewRumor(types.GetAccount().PrivateKey, types.GetAccount().Address, gossip.Transaction.Hash))
 		} else {
 			utils.Error(err)
-			return synchronizedGossip, err
+			return synchronizedGossip, err, true
 		}
+		//This is the first time receiving this gossip
+		this.cacheOnFirstReceive(synchronizedGossip)
 	}
-	return synchronizedGossip, nil
+	return synchronizedGossip, nil, !hasAll
 }
 
 // gossipWorker
@@ -164,6 +186,17 @@ func (this *DAPoSService) gossipWorker() {
 		case gossip = <-this.gossipChan:
 
 			go func(gossip *types.Gossip) {
+				// Find nodes in cache?
+				delegateNodes, err := types.ToNodesByTypeFromCache(services.GetCache(), types.TypeDelegate)
+				if err != nil {
+					utils.Error(err)
+					return
+				}
+				if delegateMap == nil || len(delegateMap) == 0 {
+					for _, d := range delegateNodes {
+						delegateMap[d.Address] = d
+					}
+				}
 
 				// Gossip timeout?
 				if len(gossip.Rumors) > 1 {
@@ -174,30 +207,34 @@ func (this *DAPoSService) gossipWorker() {
 						return
 					}
 				}
-
-				// Find nodes in cache?
-				delegateNodes, err := types.ToNodesByTypeFromCache(services.GetCache(), types.TypeDelegate)
-				if err != nil {
-					utils.Error(err)
-					return
-				}
-
 				// Do we have 2/3 of rumors?
 				if float32(len(gossip.Rumors)) >= float32(len(delegateNodes))*2/3 {
 					if !this.gossipQueue.Exists(gossip.Transaction.Hash) {
+						//for _, rumor := range gossip.Rumors {
+						//	utils.Info(fmt.Sprintf("rumor from: [address=%s] for [tx=%s] with [hash=%s]", rumor.Address, rumor.TransactionHash, rumor.Hash))
+						//}
 						this.gossipQueue.Push(gossip)
 
 						go func() {
 							//adding timeout as a function of tx time.  If tx is in the future, add future delta to the default timeout
 							delta := gossip.Transaction.Time - utils.ToMilliSeconds(time.Now())
 							totalMilliseconds := (types.GossipTimeout * len(delegateNodes)) + types.TxReceiveTimeout
-							timeout := time.Duration(totalMilliseconds)
+							timeout := time.Duration(totalMilliseconds) * time.Millisecond
+							utils.Debug("Timeout Queue value: ", timeout)
 							if delta > 0 {
 								timeout = time.Millisecond*time.Duration(delta) + timeout
 							}
 							time.Sleep(timeout)
 							this.timoutChan <- true
 						}()
+						//for _, node := range delegateNodes {
+						//	haveSent := gossip.HaveSent(services.GetCache(), gossip.Transaction.Hash, node.Address)
+						//
+						//	if !haveSent {
+						//		utils.Info(fmt.Sprintf("*********** Last send after 2/3 [hash=%s] to delegate [Port %d] [address=%s]", gossip.Transaction.Hash, node.HttpEndpoint.Port, node.Address))
+						//		this.peerGossipGrpc(*node, gossip)
+						//	}
+						//}
 					}
 					//No reason to keep gossiping if we are executing the transaction
 					return
@@ -218,18 +255,23 @@ func (this *DAPoSService) gossipWorker() {
 
 					//Commented out because if we have no-one left to talk to, why are we continuing?
 					//Plus it was causing me all kinds of timeout problems
-					//this.gossipChan <- gossip
+					if len(gossip.Rumors) != len(delegateNodes) {
+						utils.Debug(fmt.Sprintf("Stopped Gossiping when there are %d nodes that don't have a rumor", len(delegateNodes)-len(gossip.Rumors)))
+					}
+
 					return
 				}
+				utils.Debug(fmt.Sprintf("Picked RandomDelegate = [hash=%s] to delegate [Port %d] [address=%s]", gossip.Transaction.Hash, node.HttpEndpoint.Port, node.Address))
 
 				// Peer gossip.
-				peerGossip, err := this.peerGossipGrpc(*node, gossip)
+				//peerGossip, err := this.peerGossipGrpc(*node, gossip)
+				_, err = this.peerGossipGrpc(*node, gossip)
 				if err != nil {
-					utils.Warn(err)
+					utils.Error(err)
 					this.gossipChan <- gossip
 					return
 				}
-				this.gossipChan <- peerGossip
+				//this.gossipChan <- peerGossip
 			}(gossip)
 		}
 	}
@@ -248,15 +290,27 @@ func updateReceiptStatus(txHash, status string) {
 // getRandomDelegate
 func (this *DAPoSService) getRandomDelegate(gossip *types.Gossip, delegateNodes []*types.Node) *types.Node {
 	if len(delegateNodes) == 0 {
+		utils.Error("Delegate Nodes length is 0")
 		return nil
 	}
 
 	// Get delegates that have not rumored?
 	delegatesNotRumored := make([]*types.Node, 0)
 	for _, node := range delegateNodes {
-		if gossip.ContainsRumor(node.Address) ||
-			node.Address == disgover.GetDisGoverService().ThisNode.Address ||
-			!node.IsAvailable() {
+		haveSent := gossip.HaveSent(services.GetCache(), gossip.Transaction.Hash, node.Address)
+		containsRumor := gossip.ContainsRumor(node.Address)
+		isThisAddress := node.Address == disgover.GetDisGoverService().ThisNode.Address
+
+		if !node.IsAvailable() {
+			utils.Debug(fmt.Sprintf("Node is not available: [hash=%s] to delegate [Port %d] [address=%s]", gossip.Transaction.Hash, node.HttpEndpoint.Port, node.Address))
+		}
+		if haveSent {
+			utils.Debug(fmt.Sprintf("Have Sent: [hash=%s] to delegate [Port %d] [address=%s]", gossip.Transaction.Hash, node.HttpEndpoint.Port, node.Address))
+		}
+		if !containsRumor {
+			utils.Debug(fmt.Sprintf("Don't have a Rumor for: [hash=%s] to delegate [Port %d] [address=%s]", gossip.Transaction.Hash, node.HttpEndpoint.Port, node.Address))
+		}
+		if isThisAddress || haveSent || !node.IsAvailable() {
 			continue
 		}
 		delegatesNotRumored = append(delegatesNotRumored, node)
@@ -264,7 +318,6 @@ func (this *DAPoSService) getRandomDelegate(gossip *types.Gossip, delegateNodes 
 	if len(delegatesNotRumored) == 0 {
 		return nil
 	}
-
 	// Find random delegate.
 	rand.Seed(time.Now().UTC().UnixNano())
 	index := rand.Intn(len(delegatesNotRumored))
@@ -297,7 +350,7 @@ func (this *DAPoSService) doWork() {
 			return
 		}
 		initialRcvDuration := gossip.Rumors[0].Time - gossip.Transaction.Time
-		utils.Info("Initial Receive Duration = ", initialRcvDuration, types.TxReceiveTimeout)
+		utils.Debug("Initial Receive Duration = ", initialRcvDuration, types.TxReceiveTimeout)
 		if initialRcvDuration >= types.TxReceiveTimeout {
 			utils.Error(fmt.Sprintf("Timed out [hash=%s] %v milliseconds", gossip.Transaction.Hash, initialRcvDuration))
 			receipt = types.NewReceipt(gossip.Transaction.Hash)
@@ -314,18 +367,17 @@ func (this *DAPoSService) doWork() {
 
 // executeTransaction
 func executeTransaction(transaction *types.Transaction, receipt *types.Receipt, gossip *types.Gossip) {
-	utils.Debug("executeTransaction --> ", transaction.Hash)
+	utils.Info("executeTransaction --> ", transaction.Hash)
 	services.Lock(transaction.Hash)
 	defer services.Unlock(transaction.Hash)
 
 	txn := services.NewTxn(true)
 	defer txn.Discard()
 
-	utils.Debug("executing transaction")
 	// Has this transaction already been processed?
 	_, err := txn.Get([]byte(transaction.Key()))
 	if err == nil {
-		utils.Warn ("Already executed this transaction")
+		utils.Info("Already executed this transaction --> ", transaction.Hash)
 		return
 	}
 
@@ -410,18 +462,17 @@ func executeTransaction(transaction *types.Transaction, receipt *types.Receipt, 
 	case types.TypeExecuteSmartContract:
 
 		// READ PARAMS
-		// if transaction.Type == types.TypeExecuteSmartContract {
-		//contractTx, err := types.ToTransactionByAddress(txn, transaction.To)
-		//if err != nil {
-		//	utils.Error(err, utils.GetCallStackWithFileAndLineNumber())
-		//	receipt.Status = types.StatusInternalError
-		//	receipt.HumanReadableStatus = err.Error()
-		//	receipt.Cache(services.GetCache())
-		//	return
-		//}
+		contractTx, err := types.ToTransactionByAddress(txn, transaction.To)
+		if err != nil {
+			utils.Error(err, utils.GetCallStackWithFileAndLineNumber())
+			receipt.Status = types.StatusInternalError
+			receipt.HumanReadableStatus = err.Error()
+			receipt.Cache(services.GetCache())
+			return
+		}
 
-		//transaction.Abi = contractTx.Abi
-		//transaction.Params, err = helper.GetConvertedParams(transaction)
+		transaction.Abi = contractTx.Abi
+		transaction.Params, err = helper.GetConvertedParams(transaction)
 		if err != nil {
 			utils.Error(err, utils.GetCallStackWithFileAndLineNumber())
 			receipt.Status = types.StatusInternalError

--- a/dapos/dapos_transport_grpc.go
+++ b/dapos/dapos_transport_grpc.go
@@ -151,14 +151,16 @@ func (this *DAPoSService) GossipGrpc(context context.Context, request *proto.Req
 	}
 
 	// Synchronize gossip.
-	synchronizedGossip, err := this.synchronizeGossip(gossip)
+	synchronizedGossip, err, addToChan := this.synchronizeGossip(gossip)
 	if err != nil {
 		utils.Error(err)
 		return nil, err
 	}
 
 	// Gossip what we got from our peer delegate.
-	this.gossipChan <- gossip
+	if(addToChan) {
+		this.gossipChan <- gossip
+	}
 
 	return &proto.Response{Payload: synchronizedGossip.String()}, nil
 }
@@ -167,15 +169,11 @@ func (this *DAPoSService) GossipGrpc(context context.Context, request *proto.Req
 func (this *DAPoSService) peerGossipGrpc(node types.Node, gossip *types.Gossip) (*types.Gossip, error) {
 	utils.Debug(fmt.Sprintf("attempting to gossip with delegate [address=%s]", node.Address))
 
-	//conn, err := grpc.Dial(fmt.Sprintf("%s:%d", node.GrpcEndpoint.Host, node.GrpcEndpoint.Port), grpc.WithInsecure())
-	//if err != nil {
-	//	utils.Error(fmt.Sprintf("cannot dial seed [host=%s, port=%d]",  node.GrpcEndpoint.Host,  node.GrpcEndpoint.Port), err)
-	//	return nil, err
-	//}
-	//defer conn.Close()
-
 	conn, err := services.GetGrpcConnection(node.Address, node.GrpcEndpoint.Host, node.GrpcEndpoint.Port)
-
+	if err != nil {
+		utils.Error(fmt.Sprintf("cannot dial seed [host=%s, port=%d]",  node.GrpcEndpoint.Host,  node.GrpcEndpoint.Port), err)
+		return nil, err
+	}
 	client := proto.NewDAPoSGrpcClient(conn)
 
 	contextWithTimeout, cancel := context.WithTimeout(context.Background(), 20000*time.Millisecond)
@@ -199,8 +197,11 @@ func (this *DAPoSService) peerGossipGrpc(node types.Node, gossip *types.Gossip) 
 	}
 	remoteGossip, err := types.ToGossipFromJson([]byte(response.Payload))
 	if err != nil {
+		utils.Error(err)
 		return nil, err
 	}
+	utils.Debug(fmt.Sprintf("sent gossip [hash=%s] to delegate [Port %d] [address=%s]", gossip.Transaction.Hash, node.HttpEndpoint.Port, node.Address))
+	remoteGossip.CacheSentDelegate(services.GetCache(), gossip.Transaction.Hash, node.Address)
 
 	return remoteGossip, err
 }

--- a/dapos/dapos_transport_http.go
+++ b/dapos/dapos_transport_http.go
@@ -58,7 +58,6 @@ func (this *DAPoSService) WithHttp() *DAPoSService {
 
 	services.GetHttpRouter().HandleFunc("/v1/receipts/{hash}", this.unsupportedFunctionHandler).Methods("GET")
 
-
 	return this
 }
 
@@ -154,7 +153,6 @@ func (this *DAPoSService) newTransactionHandler(responseWriter http.ResponseWrit
 
 	if transaction.Type == types.TypeExecuteSmartContract {
 		contractTx, err := types.ToTransactionByAddress(txn, transaction.To)
-
 		if err != nil {
 			utils.Error(err)
 			services.Error(responseWriter, fmt.Sprintf(`{"status":"%s: Could not find contract with address %s"}`, types.StatusNotFound, transaction.To), http.StatusBadRequest)


### PR DESCRIPTION
The gossipworker was not efficiently handling gossip and we had an overload of gossiping that was really problematic.  Big change was to separate who delegates have sent to and who they received from. Those are handled enirely separate now so that we can validate on recieve and not send to the same delegate many times.