### PR TITLE
DG-885-2

### DIFF
--- a/commons/helper/abi_helper.go
+++ b/commons/helper/abi_helper.go
@@ -1,7 +1,6 @@
 package helper
 
 import (
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -49,13 +48,17 @@ func GetConvertedParams(tx *types.Transaction) ([]interface{}, error) {
 						return nil, errors.New(msg)
 					}
 					result = append(result, addressAsByteArray)
-				} else if arg.Type.T == abi.BytesTy{
-					params, valErr := base64.StdEncoding.DecodeString(tx.Params[i].(string))
+				} else if arg.Type.T == abi.BytesTy {
+					//params, valErr := base64.StdEncoding.DecodeString(tx.Params[i].(string))
+					str := tx.Params[i].(string)
+					value := []byte(str)
+
 					if err != nil{
-						msg := fmt.Sprintf("Invalid value provided for method %s: %v", tx.Method, valErr.Error())
-						return nil, errors.New(msg)
+						//msg := fmt.Sprintf("Invalid value provided for method %s: %v", tx.Method, valErr.Error())
+						//return nil, errors.New(msg)
+						return nil, err
 					}
-					result = append(result, params)
+					result = append(result, value)
 				} else {
 					value, valErr := getValue(arg, tx.Params[i])
 					if valErr != nil {

--- a/dapos/dapos_handshake.go
+++ b/dapos/dapos_handshake.go
@@ -34,6 +34,8 @@ import (
 	"github.com/dispatchlabs/disgo/dvm/ethereum/abi"
 	"github.com/dispatchlabs/disgo/dvm/ethereum/params"
 	"math"
+	"encoding/base64"
+	"bytes"
 )
 
 var delegateMap = map[string]*types.Node{}
@@ -667,6 +669,19 @@ func processDVMResult(transaction *types.Transaction, dvmResult *dvm.DVMResult, 
 					} else {
 						errorToReturn = err
 						utils.Error(err)
+					}
+					for i, arg := range method.Outputs {
+						if arg.Type.T == abi.BytesTy {
+							valBytes := receipt.ContractResult[i].([]byte)
+							base64Bytes := make([]byte, base64.StdEncoding.DecodedLen(len(valBytes)))
+							_, valErr := base64.StdEncoding.Decode(base64Bytes, valBytes)
+							utils.Info(fmt.Sprintf("byteString = %v and base64Text = %v", string(valBytes), string(base64Bytes)))
+							if valErr != nil {
+								utils.Error(valErr)
+							}
+							base64Bytes = bytes.Trim(base64Bytes, "\x00")
+							receipt.ContractResult[i] = string(base64Bytes)
+						}
 					}
 				}
 			}

--- a/dapos/dapos_transport_http.go
+++ b/dapos/dapos_transport_http.go
@@ -188,7 +188,7 @@ func (this *DAPoSService) newTransactionHandler(responseWriter http.ResponseWrit
 			return
 		}
 		transaction.Abi = contractTx.Abi
-		transaction.Params, err = helper.GetConvertedParams(transaction)
+		_, err = helper.GetConvertedParams(transaction)
 		if err != nil {
 			utils.Error("Paramater type error", err)
 			services.Error(responseWriter, fmt.Sprintf(`{"status":"%s: %v"}`, types.StatusJsonParseError, err), http.StatusBadRequest)


### PR DESCRIPTION
Sorry I had to use -2.  I did not notice there was a much older branch out there for 885 that is still active.  I reviewed changes to it and it should be deleted.

since the []byte return value is automatically converted to base64, it must be decoded and I found that the VM adds null termination, so that must be trimmed from the end as well.  One important note is to make sure that "string" is the expected result.  I have this feeling that this issue might have cases where we want to keep the base64 or the base64 bytes.

In addition, the original decoding that was in abi_helper was unnecessary (and was incorrectly being done twice through the logic, so I have cleaned that up as well)