### PR TITLE
DG-992 Added Version

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -44,6 +44,7 @@ import (
 	"os/exec"
 )
 
+
 // Server -
 type Server struct {
 	services []types.IService
@@ -61,7 +62,7 @@ func NewServer() *Server {
 
 // Go
 func (server *Server) Go() {
-	utils.Info(fmt.Sprintf("booting Disgo v%s...", types.Version))
+	utils.Info(fmt.Sprintf("booting Disgo ..."))
 
 	// Run update?
 	fileName := "." + string(os.PathSeparator) + "disgo-update"

--- a/commons/types/constants.go
+++ b/commons/types/constants.go
@@ -21,6 +21,7 @@ import (
 	"time"
 )
 
+
 //TODO: I think we need to convert these timouts and their calculations in code to nano seconds
 // Timouts -- currently calculated in milliseconds.
 const (
@@ -31,10 +32,6 @@ const (
 	UnavailableNodeTimeout = float64(time.Second * 5)
 )
 
-// Requests
-const (
-	Version = "2.4.0"
-)
 
 // Statuses
 const (

--- a/commons/types/node.go
+++ b/commons/types/node.go
@@ -34,6 +34,7 @@ type Node struct {
 	Type         string    `json:"type,omitempty"`
 	Status       string    `json:"status,omitempty"`
 	StatusTime   time.Time `json:"statusTime,omitempty"`
+	Version      *Version  `json:"version,omitempty"`
 }
 
 func (this Node) IsAvailable() bool {

--- a/commons/types/version.go
+++ b/commons/types/version.go
@@ -11,6 +11,10 @@ import (
 	"io/ioutil"
 )
 
+const (
+	defaultVersion = "2.4.0"
+)
+
 type Version struct {
 	Version		string
 	BuildTime	string
@@ -63,7 +67,7 @@ func getDefaultVersion() *Version {
 		t.Year(), t.Month(), t.Day(),
 		t.Hour(), t.Minute(), t.Second())
 	return &Version{
-		Version: "2.4.0",
+		Version: defaultVersion,
 		BuildTime: tm,
 	}
 }

--- a/commons/types/version.go
+++ b/commons/types/version.go
@@ -1,0 +1,78 @@
+package types
+
+import (
+	"github.com/dispatchlabs/disgo/commons/utils"
+	"os"
+	"fmt"
+	"time"
+	"sync"
+	"encoding/json"
+
+	"io/ioutil"
+)
+
+type Version struct {
+	Version		string
+	BuildTime	string
+}
+
+var versionInstance *Version
+var versionOnce sync.Once
+
+
+
+func SetVersion(version string, timestamp string) {
+	versionOnce.Do(func() {
+		versionInstance = &Version{
+			Version: version,
+			BuildTime: timestamp,
+		}
+	})
+}
+
+func GetVersion() *Version {
+	if versionInstance == nil {
+
+		var versionFileName = utils.GetConfigDir() + string(os.PathSeparator) + "version.json"
+		if utils.Exists(versionFileName) {
+			file, err := ioutil.ReadFile(versionFileName)
+			if err != nil {
+				utils.Error(fmt.Sprintf("unable to load version file %s", versionFileName), err)
+				os.Exit(1)
+			}
+			json.Unmarshal(file, versionInstance)
+			utils.Info(fmt.Sprintf("loaded version file %s", versionFileName))
+		} else {
+			versionInstance = getDefaultVersion()
+			file, err := os.Create(versionFileName)
+			defer file.Close()
+			if err != nil {
+				utils.Error(fmt.Sprintf("unable to create version file %s", versionFileName), err)
+				panic(err)
+			}
+			fmt.Fprintf(file, versionInstance.String())
+		}
+		utils.Info(fmt.Sprintf("generated default config file %s", versionInstance.String()))
+	}
+	return versionInstance
+}
+
+func getDefaultVersion() *Version {
+	t := time.Now()
+	tm := fmt.Sprintf("%d-%02d-%02d-%02d:%02d:%02d",
+		t.Year(), t.Month(), t.Day(),
+		t.Hour(), t.Minute(), t.Second())
+	return &Version{
+		Version: "2.4.0",
+		BuildTime: tm,
+	}
+}
+
+func (this Version) String() string {
+	bytes, err := json.Marshal(this)
+	if err != nil {
+		utils.Error("unable to marshal Window", err)
+		return ""
+	}
+	return string(bytes)
+}

--- a/disgover/disgover_service.go
+++ b/disgover/disgover_service.go
@@ -45,6 +45,7 @@ func GetDisGoverService() *DisGoverService {
 				GrpcEndpoint: types.GetConfig().GrpcEndpoint,
 				HttpEndpoint: types.GetConfig().HttpEndpoint,
 				Type:         types.TypeNode,
+				Version:      types.GetVersion(),
 			},
 			// lruCache: lCache,
 			kdht: kbucket.NewRoutingTable(
@@ -56,6 +57,7 @@ func GetDisGoverService() *DisGoverService {
 			running: false,
 		}
 	})
+	utils.Info(fmt.Sprintf("This node: Address: %s, Version: %s", disGoverServiceInstance.ThisNode.Address, disGoverServiceInstance.ThisNode.Version))
 	return disGoverServiceInstance
 }
 

--- a/main.go
+++ b/main.go
@@ -20,11 +20,21 @@ package main
 import (
 	"github.com/dispatchlabs/disgo/bootstrap"
 	"github.com/dispatchlabs/disgo/commons/utils"
+	"github.com/dispatchlabs/disgo/commons/types"
 )
+
+var version string
+var date string
 
 func main() {
 	utils.InitMainPackagePath()
 	utils.InitializeLogger()
+	if version == "" {
+		utils.Error("You have not specified a version when built, please see documentation.")
+	} else {
+		types.SetVersion(version, date)
+	}
+
 	server := bootstrap.NewServer()
 	server.Go()
 }

--- a/main.go
+++ b/main.go
@@ -29,11 +29,9 @@ var date string
 func main() {
 	utils.InitMainPackagePath()
 	utils.InitializeLogger()
-	if version == "" {
-		utils.Error("You have not specified a version when built, please see documentation.")
-	} else {
+	if version != "" {
 		types.SetVersion(version, date)
-	}
+	} 
 
 	server := bootstrap.NewServer()
 	server.Go()


### PR DESCRIPTION
attached to the node object.  Can add simple logic at startup to make sure all nodes are running the same version (could be done in the seed to add to the valid list of delegates