### PR TITLE
DG 1045 Rate Limiting Fix

### DIFF
--- a/commons/helper/window_helper.go
+++ b/commons/helper/window_helper.go
@@ -26,6 +26,7 @@ func AddHertz(txn *badger.Txn, cache *cache.Cache, hertz uint64) *types.Window {
 
 		window.AddHertz(cache, hertz)
 		CalcSlopeForWindow(cache, window)
+		SetPreviousCeiling(cache, window)
 		types.GetCurrentTTL(cache, window)
 	} else {
 		window = val.(*types.Window)
@@ -59,6 +60,14 @@ func CalcSlopeForWindow(cache *cache.Cache, window *types.Window) {
 		window.Slope, _ = utils.LinearRegression(&points)
 	} else {
 		window.Slope = 0
+	}
+}
+
+func SetPreviousCeiling(cache *cache.Cache, window *types.Window) {
+	if previousWindow, ok := types.ToWindowFromCache(cache, window.Id-1); !ok {
+		window.HzCeiling = 0
+	} else {
+		window.HzCeiling = previousWindow.HzCeiling
 	}
 }
 

--- a/commons/types/rate_limit_test.go
+++ b/commons/types/rate_limit_test.go
@@ -264,4 +264,6 @@ func TestConfigSettings(t *testing.T) {
 	utils.Info("NumWindows: ", GetConfig().RateLimits.NumWindows)
 	utils.Info("TxPerMinute: ", GetConfig().RateLimits.TxPerMinute)
 	utils.Info("AvgHzPerTxn: ", GetConfig().RateLimits.AvgHzPerTxn)
+	utils.Info("MinTTL: ", GetConfig().RateLimits.MinTTL)
+	utils.Info("MaxTTL: ", GetConfig().RateLimits.MaxTTL)
 }

--- a/commons/types/window.go
+++ b/commons/types/window.go
@@ -1,22 +1,22 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/dgraph-io/badger"
+	"github.com/dispatchlabs/disgo/commons/utils"
 	"github.com/patrickmn/go-cache"
 	"time"
-	"encoding/json"
-	"github.com/dispatchlabs/disgo/commons/utils"
-	"github.com/dgraph-io/badger"
 )
 
 type Window struct {
-	Id              int64
-	Sum				uint64
-	Entries         int64
-	Slope           float64
-	TTL 			time.Duration
+	Id        int64
+	Sum       uint64
+	Entries   int64
+	Slope     float64
+	TTL       time.Duration
+	HzCeiling uint64
 }
-
 
 func NewWindow() *Window {
 	epoch := time.Unix(0, int64(GetConfig().RateLimits.EpochTime))
@@ -24,10 +24,11 @@ func NewWindow() *Window {
 	utils.Debug("Minutes since epoch: ", minutesSinceEpoch)
 
 	return &Window{
-		Id: minutesSinceEpoch,
-		Sum: 0,
-		Entries: 0,
-		Slope: 0,
+		Id:        minutesSinceEpoch,
+		Sum:       0,
+		Entries:   0,
+		Slope:     0,
+		HzCeiling: 0,
 	}
 }
 


### PR DESCRIPTION
On a Herz spike a HzCeiling is set on windows to note the Hz value at the time that the TTL goes to max. The algorithm will start lowering the TTL only when Hz goes lower than the Ceiling. 

This accounts for negative slopes but still high Hz values. 

