### PR TITLE
DG-1098

### DIFF
--- a/commons/helper/abi_helper.go
+++ b/commons/helper/abi_helper.go
@@ -16,7 +16,10 @@ import (
 
 func GetConvertedParams(tx *types.Transaction) ([]interface{}, error) {
 	utils.Info("GetConvertedParams --> ", tx.Params)
-	params := tx.ToParams()
+	params, err := tx.ToParams()
+	if err != nil {
+		return nil, err
+	}
 	theABI, err := GetABI(tx.Abi)
 	if err != nil {
 		return nil, err

--- a/commons/types/transaction.go
+++ b/commons/types/transaction.go
@@ -695,13 +695,13 @@ func (this Transaction) NewSignature(privateKey string) (string, error) {
 }
 
 // ToParams
-func (this Transaction) ToParams() []interface{} {
+func (this Transaction) ToParams() ([]interface{}, error) {
 	params := make([]interface{},0)
 	err := json.Unmarshal([]byte(this.Params), &params)
 	if err != nil {
-		return nil
+		return nil, errors.New("Params are not in a valid format (should be a json string of array of params)")
 	}
-	return params
+	return params, nil
 }
 
 // Verify


### PR DESCRIPTION
Since we moved to string params that is converted, this check was missed.