### PR TITLE
DG-1083

### DIFF
--- a/dvm/vmstatehelperimplemtations/implementation.go
+++ b/dvm/vmstatehelperimplemtations/implementation.go
@@ -44,9 +44,9 @@ var (
 	IsDemo             = false
 
 	DefaultValue    = big.NewInt(0)
-	DefaultGas      = big.NewInt(1000000000000)
+	DefaultGas      = big.NewInt(5000000)
 	DefaultGasPrice = big.NewInt(0)
-	DefaultGasLimit = 1000000000000
+	DefaultGasLimit = 5000000
 	DefaultDivvy    = int64(0)
 )
 


### PR DESCRIPTION
The min hertz/gas was set to 1 trillion, so an intdeterminate loop could run seemingly forever.  I lowered to a reasonable number after some testing.
High priority for post-main-net is to add hert limits to the initial transaction request and at least set the limit to available hertz if nothing is specified.