### PR TITLE
DG-1103

### DIFF
--- a/commons/types/rate_limit.go
+++ b/commons/types/rate_limit.go
@@ -62,6 +62,13 @@ func (this *RateLimit) Set(window Window, txn *badger.Txn, cache *cache.Cache) e
 
 func (this *RateLimit) cache(window Window, cache *cache.Cache) {
 	cache.Set(getAccountRateLimitKey(this.Address), this.Existing, TransactionCacheTTL)
+	utils.Debug("Current Window TTL = ", window.TTL)
+
+	//if this transaction is already in the cache, don't add it again
+	value, _ := cache.Get(getTxRateLimitKey(this.TxRateLimit.TxHash))
+	if value != nil {
+		return
+	}
 	cache.Set(getTxRateLimitKey(this.TxRateLimit.TxHash), this.TxRateLimit, window.TTL)
 }
 

--- a/commons/types/window.go
+++ b/commons/types/window.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dispatchlabs/disgo/commons/utils"
 	"github.com/patrickmn/go-cache"
 	"time"
+	"github.com/pkg/errors"
 )
 
 type Window struct {
@@ -124,4 +125,73 @@ func (this Window) ToPrettyJson() string {
 		return ""
 	}
 	return string(bytes)
+}
+
+func (this *Window) UnmarshalJSON(bytes []byte) error {
+	var jsonMap map[string]interface{}
+	error := json.Unmarshal(bytes, &jsonMap)
+	if error != nil {
+		return error
+	}
+	if jsonMap["id"] != nil {
+		val, ok := jsonMap["id"].(float64)
+		if !ok {
+			return errors.Errorf("value for field 'id' must be a int")
+		}
+		this.Id = int64(val)
+	}
+	if jsonMap["sum"] != nil {
+		val, ok := jsonMap["sum"].(float64)
+		if !ok {
+			return errors.Errorf("value for field 'sum' must be a uint")
+		}
+		this.Sum = uint64(val)
+	}
+	if jsonMap["entries"] != nil {
+		val, ok := jsonMap["entries"].(float64)
+		if !ok {
+			return errors.Errorf("value for field 'entries' must be a int")
+		}
+		this.Entries = int64(val)
+	}
+	if jsonMap["slope"] != nil {
+		val, ok := jsonMap["slope"].(float64)
+		if !ok {
+			return errors.Errorf("value for field 'slope' must be a float")
+		}
+		this.Slope = val
+	}
+	if jsonMap["ttl"] != nil {
+		val, ok := jsonMap["entries"].(time.Duration)
+		if !ok {
+			return errors.Errorf("value for field 'ttl' must be a int")
+		}
+		this.TTL = val
+	}
+	if jsonMap["hzCeiling"] != nil {
+		val, ok := jsonMap["hzCeiling"].(float64)
+		if !ok {
+			return errors.Errorf("value for field 'entries' must be a int")
+		}
+		this.HzCeiling = uint64(val)
+	}
+	return nil
+}
+
+func (this Window) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Id        int64				`json:"hash"`
+		Sum       uint64			`json:"hash"`
+		Entries   int64				`json:"hash"`
+		Slope     float64			`json:"hash,omitempty"`
+		TTL       time.Duration		`json:"hash,omitempty"`
+		HzCeiling uint64			`json:"hash,omitempty"`
+	}{
+		Id: 		this.Id,
+		Sum:     	this.Sum,
+		Entries:  	this.Entries,
+		Slope:    	this.Slope,
+		TTL:  		this.TTL,
+		HzCeiling:  this.HzCeiling,
+	})
 }

--- a/commons/utils/linear_regression.go
+++ b/commons/utils/linear_regression.go
@@ -21,6 +21,9 @@ func LinearRegression(points *[]Point) (a float64, b float64) {
 	}
 
 	base := (n*sumXX - sumX*sumX)
+	if base == 0 {
+		return 0.0, 0.0
+	}
 	a = (n*sumXY - sumX*sumY) / base
 	b = (sumXX*sumY - sumXY*sumX) / base
 

--- a/dapos/dapos_handshake.go
+++ b/dapos/dapos_handshake.go
@@ -35,7 +35,6 @@ import (
 	"github.com/dispatchlabs/disgo/dvm/ethereum/params"
 	"encoding/base64"
 	"bytes"
-	"math"
 )
 
 var delegateMap = map[string]*types.Node{}
@@ -601,13 +600,13 @@ func executeTransaction(transaction *types.Transaction, receipt *types.Receipt, 
 			receipt.Cache(services.GetCache())
 			return
 		}
-
 		//Also lock up for the receiver
 		//This code is way down here so that the rate limiting works "after" the account is saved.  New accounts don't exist until the above persist.
 		//Take the lower value of Hertz for this transaction and the receivers balance (so we don't lock more than they have)
-		maxToLock := math.Min(float64(toAccount.Balance.Uint64()), float64(hertz))
+		//No longer doing this and handling it on the request balance side
+		//maxToLock := math.Min(float64(toAccount.Balance.Uint64()), float64(hertz))
 
-		rateLimitTo, err := types.NewRateLimit(transaction.To, transaction.Hash, uint64(maxToLock))
+		rateLimitTo, err := types.NewRateLimit(transaction.To, transaction.Hash, hertz)
 		if err != nil {
 			utils.Error(err)
 		}

--- a/dvm/dvm_api.go
+++ b/dvm/dvm_api.go
@@ -29,6 +29,7 @@ import (
 	ethTypes "github.com/dispatchlabs/disgo/dvm/ethereum/types"
 	"github.com/dispatchlabs/disgo/dvm/vmstatehelperimplemtations"
 	"github.com/dispatchlabs/disgo/commons/helper"
+	"github.com/dispatchlabs/disgo/dvm/ethereum/vm"
 )
 
 // DeploySmartContract -
@@ -255,7 +256,10 @@ func (dvm *DVMService) ExecuteSmartContract(tx *commonTypes.Transaction) (*DVMRe
 	if execError != nil {
 		utils.Error(execError)
 		// return nil, execError
-
+		hertzUsed := uint64(0)
+		if execError == vm.ErrOutOfGas {
+			hertzUsed = callMsg.Gas()
+		}
 		return &DVMResult{
 			From:                     crypto.GetAddressBytes(tx.From),
 			To:                       crypto.GetAddressBytes(tx.To),
@@ -269,7 +273,7 @@ func (dvm *DVMService) ExecuteSmartContract(tx *commonTypes.Transaction) (*DVMRe
 			Divvy:  vmstatehelperimplemtations.DefaultDivvy,
 			Status: ethTypes.ReceiptStatusFailed,
 			// HertzCost:           receipt.GasUsed,
-			// CumulativeHertzUsed: receipt.CumulativeGasUsed,
+			CumulativeHertzUsed: 	hertzUsed,
 			// Bloom:               receipt.Bloom,
 			// Logs:                receipt.Logs,
 		}, execError

--- a/sdk/endpoints.go
+++ b/sdk/endpoints.go
@@ -133,13 +133,15 @@ func GetAccount(delegateNode types.Node, address string) (*types.Account, error)
 		return nil, errors.Errorf("'data' is missing from response")
 	}
 
+	value, _ :=	jsonMap["data"]
+	fmt.Printf(value)
+
 	// Unmarshal account.
 	var account *types.Account
 	err = json.Unmarshal(jsonMap["data"], &account)
 	if err != nil {
 		return nil, err
 	}
-
 	return account, nil
 }
 

--- a/sdk/endpoints.go
+++ b/sdk/endpoints.go
@@ -133,9 +133,6 @@ func GetAccount(delegateNode types.Node, address string) (*types.Account, error)
 		return nil, errors.Errorf("'data' is missing from response")
 	}
 
-	value, _ :=	jsonMap["data"]
-	fmt.Printf(value)
-
 	// Unmarshal account.
 	var account *types.Account
 	err = json.Unmarshal(jsonMap["data"], &account)


### PR DESCRIPTION
So in the code, we set the amount deducted for the rate limit in the cache.  Problem is, that's a single key value for the Tx.hash.  Because we are also deducting from the receiver, we were overwriting the "amount" for that transaction based on the minimum of the receiver balance vs the hertz used ( so zero balance for a contract=zero deduction!!!! ).   So the tx.hash rate limit "amount" was being set back to zero.  So when we do the deduction for each tx.hash that is still under the TTL in the cache, the deduction for that tx.hash was zero.