### PR TITLE
3.2.0 - Transaction Type 3 (Call) 

### DIFF
--- a/commons/types/constants.go
+++ b/commons/types/constants.go
@@ -70,7 +70,8 @@ const (
 	TypeTransferTokens       = 0
 	TypeDeploySmartContract  = 1
 	TypeExecuteSmartContract = 2
-	TypeUpdateCode			 = 3
+	TypeReadSmartContract	 = 3
+	TypeUpdateCode		 	 = 4
 )
 
 // Persistence TTLs

--- a/commons/types/transaction.go
+++ b/commons/types/transaction.go
@@ -611,13 +611,17 @@ func NewDeployContractTransaction(privateKey string, from string, code string, a
 }
 
 // NewExecuteContractTransaction -
-func NewExecuteContractTransaction(privateKey string, from string, to string, method string, params string, timeInMiliseconds int64) (*Transaction, error) {
+func NewExecuteContractTransaction(privateKey string, from string, to string, method string, params string, write bool, timeInMiliseconds int64) (*Transaction, error) {
 	if method == "" {
 		return nil, errors.Errorf("cannot have empty method")
 	}
 	var err error
 	transaction := &Transaction{}
-	transaction.Type = TypeExecuteSmartContract
+	if write {
+		transaction.Type = TypeExecuteSmartContract
+	} else {
+		transaction.Type = TypeReadSmartContract
+	}
 	transaction.From = from
 	transaction.To = to
 	transaction.Method = method

--- a/dapos/dapos_api.go
+++ b/dapos/dapos_api.go
@@ -175,6 +175,24 @@ func (this *DAPoSService) NewTransaction(transaction *types.Transaction) *types.
 	return response
 }
 
+//CallTransaction
+func (this *DAPoSService) CallTransaction(transaction *types.Transaction) *types.Receipt {
+	receipt := new(types.Receipt)
+
+	// Delegate?
+	if disgover.GetDisGoverService().ThisNode.Type == types.TypeDelegate {
+		receipt = CallTransactionInDVM(transaction)
+	} else {
+		receipt = new(types.Receipt)
+		receipt.Status = types.StatusNotDelegate
+		receipt.HumanReadableStatus = types.StatusNotDelegateAsHumanReadable
+	}
+
+	utils.Debug(fmt.Sprintf("new transaction [hash=%s, status=%s]", transaction.Hash, receipt.Status))
+	return receipt
+
+}
+
 // GetTransaction
 func (this *DAPoSService) GetTransaction(hash string) *types.Response {
 	txn := services.NewTxn(false)

--- a/dapos/dapos_handshake.go
+++ b/dapos/dapos_handshake.go
@@ -819,12 +819,69 @@ func ExecuteTransaction(transaction *types.Transaction, receipt *types.Receipt, 
 	}
 }
 
+//Call Transaction
+func CallTransactionInDVM(transaction *types.Transaction) *types.Receipt {
+	utils.Info("callTransaction --> ", transaction.Hash)
+
+	txn := services.NewTxn(true)
+	defer txn.Discard()
+
+	receipt := new(types.Receipt)
+
+	// READ PARAMS
+	contractTx, err := types.ToTransactionByAddress(txn, transaction.To)
+	if err != nil {
+		utils.Error(err, utils.GetCallStackWithFileAndLineNumber())
+		receipt.Status = types.StatusInternalError
+		receipt.HumanReadableStatus = err.Error()
+		receipt.Cache(services.GetCache())
+		return receipt
+	}
+
+	transaction.Abi = contractTx.Abi
+	_, err = helper.GetConvertedParams(transaction)
+	if err != nil {
+		utils.Error(err, utils.GetCallStackWithFileAndLineNumber())
+		receipt.Status = types.StatusInternalError
+		receipt.HumanReadableStatus = err.Error()
+		receipt.Cache(services.GetCache())
+		return receipt
+	}
+
+
+	//Run the TX through the dvm
+	dvmService := dvm.GetDVMService()
+	dvmResult, err1 := dvmService.ExecuteSmartContract(transaction)
+	if err1 != nil {
+		utils.Error(err, utils.GetCallStackWithFileAndLineNumber())
+	}
+
+	err = processDVMResult(transaction, dvmResult, receipt)
+	if err != nil {
+		utils.Error(err)
+
+		receipt.Status = types.StatusInternalError
+		receipt.HumanReadableStatus = err.Error()
+
+		if err != nil {
+			utils.Error(err)
+		}
+
+		return receipt
+	}
+	receipt.ContractAddress = transaction.To
+	receipt.Status = types.StatusOk
+	receipt.TransactionHash = transaction.Hash
+
+	return receipt
+}
+
 //TODO: implement if useful
 //func commit(transaction *types.Transaction) {}
 // processDVMResult
 func processDVMResult(transaction *types.Transaction, dvmResult *dvm.DVMResult, receipt *types.Receipt) error {
-	utils.Info("######### DUMPING-DVMResult #########")
-	utils.Info(dvmResult)
+	//utils.Info("######### DUMPING-DVMResult #########")
+	//utils.Info(dvmResult)
 
 	if dvmResult.ContractMethodExecError != nil {
 		utils.Error(dvmResult.ContractMethodExecError)

--- a/dapos/dapos_service.go
+++ b/dapos/dapos_service.go
@@ -108,9 +108,11 @@ func (this *DAPoSService) CreateGenesisAccount() error {
 
 	genesisAccount, err := types.GetGenesisAccount()
 	if err != nil {
+		return err
 		utils.Error(err)
 	}
 	_, err = types.ToAccountByAddress(txn, genesisAccount.Address)
+
 	if err != nil {
 		if err == badger.ErrKeyNotFound {
 			//genesis not yet in db
@@ -118,10 +120,10 @@ func (this *DAPoSService) CreateGenesisAccount() error {
 			if err != nil {
 				return err
 			}
-		} else {
-			//genesis is already in db
-			return errors.New("genesis already exists")
+			return txn.Commit(nil)
 		}
 	}
-	return txn.Commit(nil)
+	//genesis is already in db
+	return errors.New("genesis already exists")
+
 }

--- a/dapos/dapos_service.go
+++ b/dapos/dapos_service.go
@@ -90,7 +90,7 @@ func (this *DAPoSService) disGoverServiceInitFinished() {
 
 		}
 
-	} else if err != nil && err != errors.New("genesis already exists") {
+	} else if err != nil && err.Error() != "genesis already exists" {
 		services.GetDbService().Close()
 		utils.Fatal("unable to create genesis account", err)
 	}

--- a/dvm/dvm_api.go
+++ b/dvm/dvm_api.go
@@ -279,12 +279,40 @@ func (dvm *DVMService) ExecuteSmartContract(tx *commonTypes.Transaction) (*DVMRe
 		}, execError
 	}
 
-	// Commit the change
-	_, err = stateHelper.Commit() // returns `hashOfTrieRootNode` but don't use below
-	if err != nil {
-		utils.Error(err)
-		// return nil, err
+	// Commit the change (if not a read)
+	if tx.Type != commonTypes.TypeReadSmartContract {
+		_, err = stateHelper.Commit() // returns `hashOfTrieRootNode` but don't use below
+		if err != nil {
+			utils.Error(err)
+			// return nil, err
 
+			return &DVMResult{
+				From:                     crypto.GetAddressBytes(tx.From),
+				To:                       crypto.GetAddressBytes(tx.To),
+				ABI:                      tx.Abi,
+				StorageState:             stateHelper,
+				ContractAddress:          crypto.GetAddressBytes(tx.To),
+				ContractMethod:           tx.Method,
+				ContractMethodExecError:  execError,
+				ContractMethodExecResult: nil,
+
+				Divvy:  vmstatehelperimplemtations.DefaultDivvy,
+				Status: ethTypes.ReceiptStatusFailed,
+				// HertzCost:           receipt.GasUsed,
+				// CumulativeHertzUsed: receipt.CumulativeGasUsed,
+				// Bloom:               receipt.Bloom,
+				// Logs:                receipt.Logs,
+			}, execError
+		}
+
+		// Get info about the TX
+		bytes, _ := hex.DecodeString(tx.Hash)
+		receipt, err := dvm.getReceipt(bytes)
+		if err != nil {
+			utils.Error(err)
+		}
+
+		// Return the state of the storage and the execution result
 		return &DVMResult{
 			From:                     crypto.GetAddressBytes(tx.From),
 			To:                       crypto.GetAddressBytes(tx.To),
@@ -293,37 +321,34 @@ func (dvm *DVMService) ExecuteSmartContract(tx *commonTypes.Transaction) (*DVMRe
 			ContractAddress:          crypto.GetAddressBytes(tx.To),
 			ContractMethod:           tx.Method,
 			ContractMethodExecError:  execError,
-			ContractMethodExecResult: nil,
+			ContractMethodExecResult: execResult,
 
-			Divvy:  vmstatehelperimplemtations.DefaultDivvy,
-			Status: ethTypes.ReceiptStatusFailed,
-			// HertzCost:           receipt.GasUsed,
-			// CumulativeHertzUsed: receipt.CumulativeGasUsed,
-			// Bloom:               receipt.Bloom,
-			// Logs:                receipt.Logs,
-		}, execError
+			Divvy:               vmstatehelperimplemtations.DefaultDivvy,
+			Status:              receipt.Status,
+			HertzCost:           receipt.GasUsed,
+			CumulativeHertzUsed: receipt.CumulativeGasUsed,
+			Bloom:               receipt.Bloom,
+			Logs:                receipt.Logs,
+		}, nil
+
+	} else {
+		// return the execution results for an READ execute without the ethType Receipts
+		return &DVMResult{
+			From:                     crypto.GetAddressBytes(tx.From),
+			To:                       crypto.GetAddressBytes(tx.To),
+			ABI:                      tx.Abi,
+			StorageState:             stateHelper,
+			ContractAddress:          crypto.GetAddressBytes(tx.To),
+			ContractMethod:           tx.Method,
+			ContractMethodExecError:  execError,
+			ContractMethodExecResult: execResult,
+
+			Divvy:               vmstatehelperimplemtations.DefaultDivvy,
+			Status:              0,
+			HertzCost:           0,
+			CumulativeHertzUsed: 0,
+			Bloom:               ethTypes.Bloom{},
+			Logs:                nil,
+		}, nil
 	}
-
-	// Get info about the TX
-	bytes, _ := hex.DecodeString(tx.Hash)
-	receipt, err := dvm.getReceipt(bytes)
-
-	// Return the state of the storage and the execution result
-	return &DVMResult{
-		From:                     crypto.GetAddressBytes(tx.From),
-		To:                       crypto.GetAddressBytes(tx.To),
-		ABI:                      tx.Abi,
-		StorageState:             stateHelper,
-		ContractAddress:          crypto.GetAddressBytes(tx.To),
-		ContractMethod:           tx.Method,
-		ContractMethodExecError:  execError,
-		ContractMethodExecResult: execResult,
-
-		Divvy:               vmstatehelperimplemtations.DefaultDivvy,
-		Status:              receipt.Status,
-		HertzCost:           receipt.GasUsed,
-		CumulativeHertzUsed: receipt.CumulativeGasUsed,
-		Bloom:               receipt.Bloom,
-		Logs:                receipt.Logs,
-	}, nil
 }

--- a/localapi/localapi_transport_http.go
+++ b/localapi/localapi_transport_http.go
@@ -200,7 +200,7 @@ func (this *LocalAPIService) executeHandler(responseWriter http.ResponseWriter, 
 		return
 	}
 
-	response, err := sdk.ExecuteSmartContractTransaction(
+	response, err := sdk.ExecuteWriteTransaction(
 		*delegates[0],
 		types.GetKey(),
 		disgover.GetDisGoverService().ThisNode.Address,

--- a/sdk/endpoints.go
+++ b/sdk/endpoints.go
@@ -231,29 +231,35 @@ func DeploySmartContract(delegateNode types.Node, privateKey, from, code, abi st
 }
 
 // ExecuteSmartContractTransaction - Execute a smart contract, get the TX hash as result
-func ExecuteSmartContractTransaction(delegateNode types.Node, privateKey, from, to, method string, params string) (string, error) {
-	// Create execute smart contract transaction.
-	transaction, err := types.NewExecuteContractTransaction(privateKey, from, to, method, params, utils.ToMilliSeconds(time.Now()))
+func ExecuteSmartContractTransaction(delegateNode types.Node, privateKey, from, to, method string, params string, write bool) ([]byte, string, error) {
+	transaction, err := types.NewExecuteContractTransaction(privateKey, from, to, method, params, write, utils.ToMilliSeconds(time.Now()))
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 
 	// Post transaction.
 	httpResponse, err := http.Post(fmt.Sprintf("http://%s:%d/v1/transactions", delegateNode.HttpEndpoint.Host, delegateNode.HttpEndpoint.Port), "application/json", bytes.NewBuffer([]byte(transaction.String())))
 	if err != nil {
-		return "", err
+		return nil, transaction.Hash, err
 	}
 	defer httpResponse.Body.Close()
 
 	// Read body.
 	body, err := ioutil.ReadAll(httpResponse.Body)
 	if err != nil {
-		return "", err
+		return nil, transaction.Hash, err
 	}
+
+	return body, transaction.Hash, nil
+}
+
+func ExecuteWriteTransaction(delegateNode types.Node, privateKey, from, to, method string, params string) (string, error) {
+
+	responseBody, hash, _ := ExecuteSmartContractTransaction(delegateNode, privateKey, from, to, method, params, true)
 
 	// Unmarshal response.
 	var response *types.Response
-	err = json.Unmarshal(body, &response)
+	err := json.Unmarshal(responseBody, &response)
 	if err != nil {
 		return "", err
 	}
@@ -263,7 +269,29 @@ func ExecuteSmartContractTransaction(delegateNode types.Node, privateKey, from, 
 		return "", errors.New(fmt.Sprintf("%s: %s", response.Status, response.HumanReadableStatus))
 	}
 
-	return transaction.Hash, nil
+	return hash, nil
+}
+
+// CallTransaction
+func ExecuteReadTransaction(delegateNode types.Node, privateKey, from, to, method string, params string) (*types.Receipt, error) {
+	// Create execute read smart contract transaction.
+
+	receiptBody, _, _ := ExecuteSmartContractTransaction(delegateNode, privateKey, from, to, method, params, false)
+
+
+	s := string(receiptBody[:len(receiptBody)])
+	utils.Info(s)
+
+	// Unmarshal response.
+	var receipt *types.Receipt
+	err := json.Unmarshal(receiptBody, &receipt)
+	if err != nil {
+		return receipt, err
+	}
+
+	utils.Info("the body returned from the api is:", receipt)
+
+	return receipt, nil
 }
 
 // GetTransaction


### PR DESCRIPTION
This primary function of this update is the introduction of transaction type 3: Call.

Users can now send a transaction to the delegates that returns an immediate smart-contract result from the ledger. This reduces network overhead by eliminating gossiping on frequent smart-contract reads and reduces the bloat of the ledger that has caused some stability issues.

This update also includes a fix to the genesis account startup bug. 👍