### PR TITLE
Adds gzip to json responses

### DIFF
--- a/commons/services/http_service.go
+++ b/commons/services/http_service.go
@@ -79,7 +79,7 @@ func (this *HttpService) Go() {
 		})
 		handler := cors.Handler(this.router)
 
-		err := http.ListenAndServe(listen, handler)
+		err := http.ListenAndServe(listen, utils.Gzip(handler))
 
 		// QUESTION: this line is never reached
 		utils.Error("unable to listen/serve HTTP [error=" + err.Error() + "]")

--- a/commons/utils/gzip.go
+++ b/commons/utils/gzip.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"compress/gzip"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+var gzPool = sync.Pool{
+	New: func() interface{} {
+		w := gzip.NewWriter(ioutil.Discard)
+		return w
+	},
+}
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w *gzipResponseWriter) WriteHeader(status int) {
+	w.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+func Gzip(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Encoding", "gzip")
+
+		gz := gzPool.Get().(*gzip.Writer)
+		defer gzPool.Put(gz)
+
+		gz.Reset(w)
+		defer gz.Close()
+
+		next.ServeHTTP(&gzipResponseWriter{ResponseWriter: w, Writer: gz}, r)
+	})
+}


### PR DESCRIPTION
Ads a gzip compression handler to the JSON endpoint.

During testing we found that gzip compression can reduce the amount of time to retrieve a large amount of logs by a significant factor.

If the Accept-Encoding header does not contain gzip, disgo will operate as before.